### PR TITLE
build123d discussion and reimplementation of existing `wheel.py` file

### DIFF
--- a/build123d/wheel_builder.py
+++ b/build123d/wheel_builder.py
@@ -1,0 +1,99 @@
+from build123d import *
+from math import cos, pi
+
+## Wheel
+numberSpokes = 24
+outerRadius: float = 10.75
+innerRadius: float = 10.25
+width = 6.75
+chamfering = 0.75
+
+## Core
+coreRadius = 8
+coreTolerance = 0.06  ## Distance core-cutout > core
+contactRightWidth = 1.8
+contactRightDia = 8  # converted existing to actual diameters
+hexAxleDia = 2
+hexAxleLength = 3
+leftAxleLength = 5
+leftAxleDia = hexAxleDia * cos(pi / 6)
+
+## Holder
+holderBaseDepth = 13.8  ## original 13
+holderTopDepth = 9.8
+holderHeight = 13
+holderWidth = 8.3  ## original 7
+holderAxleTolerance = 0.1
+
+with BuildSketch() as core_s:
+    Circle(coreRadius)
+    split(bisect_by=Plane.XZ.offset(leftAxleDia / 2), keep=Keep.BOTTOM)
+    split(bisect_by=Plane.YZ.offset(coreRadius - 0.5), keep=Keep.BOTTOM)
+
+with BuildPart() as wheel_p:
+    with BuildSketch() as wheel_s:
+        with BuildLine(mode=Mode.PRIVATE) as wheel_l:
+            # construction line first
+            c1 = PolarLine(
+                (0, 0), innerRadius, 360 / numberSpokes / 2, mode=Mode.PRIVATE
+            )
+            m1 = Line((outerRadius, 0), c1 @ 1)  # make half of one spoke
+            mirror(about=Plane.XZ)  # make one spoke
+        with PolarLocations(0, numberSpokes):
+            add(wheel_l.line)  # pattern all spokes
+        make_face()
+    print(len(wheel_s.sketch.edges()))
+    extrude(amount=width)
+    forchamfer = edges().filter_by(Axis.Z, reverse=True)
+    chamfer(forchamfer, chamfering)
+
+    with BuildSketch() as coreCutout_s:
+        add(core_s.sketch)  # reuse sketch
+        offset(amount=coreTolerance, kind=Kind.INTERSECTION)  # apply tolerance
+        # consider best kind              ^^^
+    extrude(amount=width, mode=Mode.SUBTRACT)
+
+
+with BuildPart() as wheelCore_p:
+    add(core_s.sketch)
+    extrude(amount=width)
+    split_pln = Plane(faces().sort_by(Axis.Y)[0])
+    with BuildSketch(Plane.XY.offset(width)) as s:
+        Circle(contactRightDia / 2)  # FYI circle accepts radius, not dia
+        split(bisect_by=split_pln, keep=Keep.BOTTOM)
+    extrude(amount=contactRightWidth)
+
+    with BuildSketch(Plane.XY.offset(width + contactRightWidth)) as s:
+        RegularPolygon(hexAxleDia / 2, 6)
+    extrude(amount=hexAxleLength)
+
+    with BuildSketch() as s:
+        Circle(leftAxleDia / 2)
+    extrude(amount=-leftAxleLength)
+
+with BuildPart() as holder_p:
+    with BuildSketch(-Plane.XY) as holder_s:
+        with Locations((0, leftAxleDia / 2)):
+            Trapezoid(
+                holderBaseDepth,
+                holderHeight,
+                90 - 8.746,  # magic number derived from existing version
+                align=(Align.CENTER, Align.MAX),
+            )
+            SlotCenterToCenter(
+                leftAxleDia,
+                leftAxleDia + 2 * holderAxleTolerance,
+                90,
+                mode=Mode.SUBTRACT,
+            )
+    extrude(amount=holderWidth)
+
+# STL Exports
+# wheel_p.part.export_stl("wheel.stl")
+# wheelCore_p.part.export_stl("wheelcore.stl")
+# holder_p.part.export_stl("holder.stl")
+
+# STEP Exports
+# wheel_p.part.export_step("wheel.step")
+# wheelCore_p.part.export_step("wheelcore.step")
+# holder_p.part.export_step("holder.step")

--- a/build123d/wheel_builder.py
+++ b/build123d/wheel_builder.py
@@ -42,7 +42,6 @@ with BuildPart() as wheel_p:
         with PolarLocations(0, numberSpokes):
             add(wheel_l.line)  # pattern all spokes
         make_face()
-    print(len(wheel_s.sketch.edges()))
     extrude(amount=width)
     forchamfer = edges().filter_by(Axis.Z, reverse=True)
     chamfer(forchamfer, chamfering)


### PR DESCRIPTION
First of all, great work on the design so far. I had a lot of fun reimplementing it using the builder API along with quite a few changes to the approach. There was only one small change to the object geometry (AFAIK) related to the tolerance between the core and core cutout (described below).

![image](https://github.com/inputlabs/prototypes_cad/assets/16868537/12a89911-52d7-4430-aca3-db657a299fb3)

Here are my general observations:

1. Use of build123d-builtins can often make the code a lot simpler and less error-prone. In particular I was able to create the same star-wheel shape with almost zero trigonometry necessary. I did this through the use of a construction line and PolarLocations (essentially a polar pattern, also consider GridLocations for grid/linear patterns in the future).
2. Use of planes for splitting objects is often a superior approach than e.g. subtracting Rectangles as done in `wheel.py` since all you need to know is the plane + offset
3. Use of offset to apply tolerances. This enables re-use of an existing sketch as I did in the included `core_s` sketch. The only change to the existing actual geometry occurred here by the way -- the existing `wheel.py` did not have tolerance applied to one of the cutout edges (the long one that roughly divided the `core_s` sketch into a semicircle).
4. The benefit of my approach to the Trapezoidal holder is debatable, but I included it in this version for your consideration. The existing approach is a pretty good idea too.
5. Using a built-in slot object to cut the axle "rest" is superior to the existing approach
6. Another big discussion is when it is best to reference existing geometry as part of creating new geometry. I personally tend to prefer avoiding referencing geometry, but there are really good arguments on both sides. From a pragmatic standpoint, referencing existing geometry like e.g. `with BuildSketch(someface) ...` can have the unintended consequence of also changing the center position. Instead I used e.g. `with BuildSketch(Plane.XY.offset(width + contactRightWidth))` which is referenced against the same variables used to create the extrusion distances. Also, referencing existing geometry also requires robust selectors, and might be impacted by code reorganization. On the positive side referencing existing geometry definitely does capture the design intent more clearly.
7. builder vs. algebra APIs -- this is a big topic as well but in the end both APIs are equally valid IMHO. In the existing algebra-based `wheel.py` the number of lines is similar or slightly less than this reworked version. I would argue that my implementation is probably easier to read and probably easier for understanding how the design evolves with version control.
8. Star import -- I used it here but it is worth considering how the script will be used and the risks involved -- further discussion from build123d's perspective here https://build123d.readthedocs.io/en/latest/tips.html#isnt-from-build123d-import-bad-practice
9. I included some STEP export statements as well
10. I have opened an issue to add a property to `RegularPolygon` to access minor_radius instead of needing to use `cos(pi/6)` as done here. https://github.com/gumyr/build123d/issues/585
